### PR TITLE
Fix imports and prediction reference

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,20 +19,21 @@ from typing import Optional
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from config import DATA_LOG, MODEL_VERSION, MODEL_PATH
-from models.safety_model import SafetyModel
-from services.external_apis import (
+
+from config import DATA_LOG
+from safety_model import SafetyModel
+from external_apis import (
     get_lapd_crime_count,
     get_forecasted_weather,
     get_openroute_path
 )
-from utils.helpers import (
+from helpers import (
     simulate_safety_features,
     encode_features,
     log_segment,
     retrain_model
 )
-from data.data_processor import DataProcessor
+from data_processor import DataProcessor
 
 # Configure logging
 logging.basicConfig(
@@ -59,7 +60,6 @@ app.add_middleware(
 # Constants
 ORS_API_KEY = "5b3ce3597851110001cf62483583f4943d614cdb84fd147b8ddf4a71"
 WEATHER_API_KEY = "2f8f46849820b1e349ceff6d33269056"
-DATA_LOG = "segment_logs.csv"
 MODEL_DIR = "models"
 MODEL_VERSION = "v2.0-rf"
 MODEL_PATH = os.path.join(MODEL_DIR, f"safety_model_{MODEL_VERSION}.pkl")
@@ -257,7 +257,7 @@ async def predict_safety(location: LocationRequest):
         }
         
         # Make prediction
-        prediction = model.predict(
+        prediction = safety_model.predict(
             list(features.values()),
             lat=location.lat,
             lon=location.lon
@@ -277,7 +277,7 @@ async def get_model_info():
     try:
         return {
             "model_path": str(MODEL_PATH),
-            "feature_names": model.feature_names,
+            "feature_names": safety_model.feature_names,
             "last_updated": datetime.fromtimestamp(MODEL_PATH.stat().st_mtime).isoformat() if MODEL_PATH.exists() else None
         }
     except Exception as e:

--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ MODEL_PATH = MODEL_DIR / "safety_model.joblib"
 SCALER_PATH = MODEL_DIR / "scaler.joblib"
 FEATURE_ENGINEERING_PATH = MODEL_DIR / "feature_engineering.joblib"
 
+# Default path for logged training data
+DATA_LOG = BASE_DIR / "segment_logs.csv"
+
 # API Configuration
 LAPD_API_URL = "https://data.lacity.org/resource/2nrs-mtv8.json"
 WEATHER_API_URL = "https://api.openweathermap.org/data/2.5/weather"

--- a/helpers.py
+++ b/helpers.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any, Optional
 import numpy as np
 
 from config import DATA_LOG
-from models.safety_model import SafetyModel
+from safety_model import SafetyModel
 
 def simulate_safety_features() -> tuple:
     lighting = random.choice(["good", "poor"])

--- a/predict.py
+++ b/predict.py
@@ -5,8 +5,8 @@ import pandas as pd
 import numpy as np
 from datetime import datetime
 
-from models.safety_model import SafetyModel
-from data.data_processor import DataProcessor
+from safety_model import SafetyModel
+from data_processor import DataProcessor
 from config import MODEL_PATH
 
 # Set up logging

--- a/safety_model.py
+++ b/safety_model.py
@@ -14,8 +14,8 @@ import optuna
 from scipy import stats
 
 from config import MODEL_PATH, SCALER_PATH, MODEL_PARAMS, FEATURE_NAMES
-from services.lapd_data import LAPDDataProcessor
-from models.feature_engineering import FeatureEngineering
+from lapd_data import LAPDDataProcessor
+from feature_engineering import FeatureEngineering
 
 logger = logging.getLogger(__name__)
 

--- a/train.py
+++ b/train.py
@@ -5,9 +5,9 @@ import pandas as pd
 import numpy as np
 from datetime import datetime
 
-from models.safety_model import SafetyModel
-from models.feature_engineering import FeatureEngineering
-from data.data_processor import DataProcessor
+from safety_model import SafetyModel
+from feature_engineering import FeatureEngineering
+from data_processor import DataProcessor
 from config import MODEL_PATH, SCALER_PATH, FEATURE_ENGINEERING_PATH
 
 # Set up logging


### PR DESCRIPTION
## Summary
- fix bad import paths that referenced non-existent packages
- centralize segment log path in config
- reference `safety_model` correctly in API prediction

## Testing
- `pytest -q`
- `python -m py_compile app.py helpers.py predict.py train.py safety_model.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6840d7cd6fac832f8838060c5a184e14