### PR TITLE
Fix safety score calculation for route mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -172,7 +172,9 @@ function App() {
       }
     })
       .then((response) => {
-        setPrediction(response.data.summary || response.data);
+        const summary = response.data.summary || {};
+        const baseScore = summary.average_score;
+        setPrediction({ ...summary, base_score: baseScore });
         setLoading(false);
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
- fix backend route-safety calculation to use numeric score
- include average score in API response summary
- compute safety score from backend data in frontend when predicting for a route

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dbf45030832fb4831a9c2705f48a